### PR TITLE
Remove unused __init__ placeholder

### DIFF
--- a/app/controllers/api/v1/__init__.rb
+++ b/app/controllers/api/v1/__init__.rb
@@ -1,4 +1,0 @@
-module Api
-  module V1
-  end
-end


### PR DESCRIPTION
## Summary
- remove empty `__init__.rb` from API v1 controller namespace

## Testing
- `RBENV_VERSION=3.2.3 bundle exec rails server -e development -d`
- `RBENV_VERSION=3.2.3 bundle exec rails routes | head -n 5` *(fails: unknown regexp options in routes.rb)*

------
https://chatgpt.com/codex/tasks/task_e_68478d54ad448326bf767377bcd4b494